### PR TITLE
Add nginx deployment with 3 replicas and port mapping

### DIFF
--- a/tasks/kubernetes/easy/nginx-deployment.yaml
+++ b/tasks/kubernetes/easy/nginx-deployment.yaml
@@ -1,6 +1,34 @@
-# Kubernetes/YAML - Easy
-
-# TODO: Create a YAML configuration file for a Kubernetes Deployment that meets the following criteria:
-# Deploys 3 replicas of the nginx container.
-# Sets the label app to web.
-# Maps port 80 in the container to port 8080 on the host.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  type: NodePort
+  selector:
+    app: web
+  ports:
+  - port: 8080
+    targetPort: 80
+    protocol: TCP


### PR DESCRIPTION
This PR adds a Kubernetes deployment file for nginx with:
- 3 replicas
- label: app=web
- container port 80 exposed as host port 8080 using a NodePort service

File path: tasks/kubernetes/easy/nginx-deployment.yaml
