### PR TITLE
Add nginx deployment YAML for Kubernetes

### DIFF
--- a/tasks/kubernetes/easy/nginx-deployment.yaml
+++ b/tasks/kubernetes/easy/nginx-deployment.yaml
@@ -1,6 +1,37 @@
-# Kubernetes/YAML - Easy
-
-# TODO: Create a YAML configuration file for a Kubernetes Deployment that meets the following criteria:
-# Deploys 3 replicas of the nginx container.
-# Sets the label app to web.
-# Maps port 80 in the container to port 8080 on the host.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  labels:
+    app: web
+spec:
+  selector:
+    app: web
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+      nodePort: 8080


### PR DESCRIPTION
## What I Did
- Created `nginx-deployment.yaml` under `tasks/kubernetes/easy/`
- Added Deployment with:
  - 3 replicas
  - Label: app=web
  - Container port 80
- Exposed it using a NodePort service on port 8080

This solves the Easy Issue for creating a Kubernetes YAML config.

