### PR TITLE
Added HomeController with Hello, Spring Boot message

### DIFF
--- a/tasks/spring-boot/easy/hello/src/main/java/org/forkcommitmerge/hello/HomeController.java
+++ b/tasks/spring-boot/easy/hello/src/main/java/org/forkcommitmerge/hello/HomeController.java
@@ -1,20 +1,15 @@
 package org.forkcommitmerge.hello;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class HomeController {
 
-    /*
-     * TASK: Create a GET mapping for the index page ("/")
-     *
-     * Requirements:
-     * 1. Create a method that handles GET requests to the root path "/"
-     * 2. Add the text "Hello, Spring Boot" to the model with the key "message"
-     * 3. Return the view name "index" to render the template
-     *
-     * The template is already set up to display the message using Thymeleaf
-     * with the expression: th:text="${message}"
-     */
-
+    @GetMapping("/")
+    public String home(Model model) {
+        model.addAttribute("message", "Hello, Spring Boot");
+        return "index";
+    }
 }


### PR DESCRIPTION
This pull request adds a simple Spring Boot controller that displays the message “Hello, Spring Boot” when accessing the root URL (http://localhost:8080/). A new file named HomeController.java was created under src/main/java/org/forkcommitmerge/hello/, containing a GET mapping for the root path (/) that adds the message to the model and returns the index view. The application was successfully built and tested locally using Java 17 and Spring Boot 3.5.5. Running the project and opening it in the browser correctly shows the “Hello, Spring Boot” message, confirming that the implementation works as intended.