### PR TITLE
Add filter and map logic to return in-stock product names

### DIFF
--- a/tasks/javascript/medium/product-stock.js
+++ b/tasks/javascript/medium/product-stock.js
@@ -11,3 +11,9 @@ const products = [
   ];
   // TODO output = [ { name: 'Book', inStock: true }, { name: 'Phone', inStock: true } ];
   // Challenge output = ['Book', 'Phone'];
+
+const result = products
+.filter((product) => product.inStock)
+.map((product)=> product.name);
+
+console.log(result);


### PR DESCRIPTION
## Pull Request Type

- [x] Solved an issue/task
- [ ] Suggest new feature/task for Fork, Commit, Merge
- [ ] Other

## Description

This PR adds a solution for filtering products that are in stock using the .filter() method.

Additionally, the extra challenge has been completed by returning only the names of the products in stock using the .map() method.

## Issue Number : #6335