### PR TITLE
feat: add Vitest test for sum function

### DIFF
--- a/tasks/typescript/vitest/easy/src/sum.test.ts
+++ b/tasks/typescript/vitest/easy/src/sum.test.ts
@@ -3,4 +3,8 @@
 import sum from "./sum";
 import { describe, expect, it } from "vitest";
 
-// TODO: Create the test required in the task
+describe("#sum", () => {
+  it("returns 0 with no numbers", () => {
+    expect(sum()).toBe(0);
+  });
+});


### PR DESCRIPTION
Implements the Vitest test suite for the `sum` function as specified in the issue.

**Changes to `sum.test.ts`:**
- Added `describe('#sum', ...)` block
- Added `it('returns 0 with no numbers', ...)` test
- Verifies `sum()` returns `0` when called with no arguments
- Does not modify `sum.ts` as instructed

Closes #6508

Co-authored-by: Egger <egger@horny-toad.com>