### PR TITLE
feat: implement startScreenTimeWarning function

### DIFF
--- a/tasks/javascript/medium/screenTimeWarning/screenTimeWarning.js
+++ b/tasks/javascript/medium/screenTimeWarning/screenTimeWarning.js
@@ -8,7 +8,16 @@
  */
 
 function startScreenTimeWarning(limitMinutes = 30) {
+  const limitMs = limitMinutes * 60 * 1000
+  const startTime = Date.now()
 
+  const intervalId = setInterval(() => {
+    const elapsed = Date.now() - startTime
+    if (elapsed >= limitMs) {
+      console.log(`You've been on this page for ${limitMinutes} minute(s). Time to take a break!`)
+      clearInterval(intervalId)
+    }
+  }, 1000)
 }
 
 // Example usage


### PR DESCRIPTION
Closes #6526

Implements `startScreenTimeWarning(limitMinutes)` using `setInterval` to track elapsed time and log a console reminder when the limit is reached. Clears the interval after firing.

Co-authored-by: Egger <egger@horny-toad.com>