### PR TITLE
feat: solve Vitest easy test - sum returns 0 with no numbers

### DIFF
--- a/tasks/typescript/vitest/easy/src/sum.test.ts
+++ b/tasks/typescript/vitest/easy/src/sum.test.ts
@@ -3,4 +3,8 @@
 import sum from "./sum";
 import { describe, expect, it } from "vitest";
 
-// TODO: Create the test required in the task
+describe("#sum", () => {
+    it("returns 0 with no numbers", () => {
+        expect(sum()).toBe(0);
+    });
+});


### PR DESCRIPTION
Closes #6508

## Changes
- Implemented the Vitest test in `tasks/typescript/vitest/easy/src/sum.test.ts`
- Added `describe`, `it`, and `expect` statements to verify `sum()` returns `0` when called with no arguments
- Test passes locally: `1 passed (1)`

Co-authored-by: Egger <egger@horny-toad.com>