### PR TITLE
fix: add GET mapping for "/" and pass message to index template

### DIFF
--- a/tasks/spring-boot/easy/hello/src/main/java/org/forkcommitmerge/hello/HomeController.java
+++ b/tasks/spring-boot/easy/hello/src/main/java/org/forkcommitmerge/hello/HomeController.java
@@ -1,20 +1,16 @@
 package org.forkcommitmerge.hello;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class HomeController {
 
-    /*
-     * TASK: Create a GET mapping for the index page ("/")
-     *
-     * Requirements:
-     * 1. Create a method that handles GET requests to the root path "/"
-     * 2. Add the text "Hello, Spring Boot" to the model with the key "message"
-     * 3. Return the view name "index" to render the template
-     *
-     * The template is already set up to display the message using Thymeleaf
-     * with the expression: th:text="${message}"
-     */
+    @GetMapping("/")
+    public String helloHandler(Model model){
+        model.addAttribute("message", "Hello, Spring Boot");
+        return "index";
+    }
 
 }


### PR DESCRIPTION
This PR fixes the root endpoint by implementing a GET mapping for "/" that adds a message to the model and returns the "index" view.

The message "Hello, Spring Boot" is passed to the template and rendered using Thymeleaf.

## Changes Made
- Added GET mapping for the root path "/"
- Added message attribute to the model
- Returned "index" view to render the template

## Result
When accessing http://localhost:8080/, the index page now displays:
"Hello, Spring Boot".

Fixes #6525