### PR TITLE
fix: Return only products in stock using .filter() (product-stock.js)

### DIFF
--- a/tasks/javascript/medium/product-stock.js
+++ b/tasks/javascript/medium/product-stock.js
@@ -1,13 +1,19 @@
 // JavaScript - Medium
 
-  // TODO: return only products that are in stock using .filter() method;
-  // Extra Challenge: return only the names of products in stock;
-
 const products = [
     { name: "Book", inStock: true },
     { name: "Pen", inStock: false },
     { name: "Phone", inStock: true },
     { name: "Mug", inStock: false }
   ];
-  // TODO output = [ { name: 'Book', inStock: true }, { name: 'Phone', inStock: true } ];
-  // Challenge output = ['Book', 'Phone'];
+
+// Return only products that are in stock using .filter() method;
+const inStockProducts = products.filter(product => product.inStock);
+// Extra Challenge: return only the names of products in stock;
+const inStockNames = products.filter(product => product.inStock).map(product => product.name);
+
+console.log(inStockProducts);
+console.log(inStockNames);
+
+// Expected output = [ { name: 'Book', inStock: true }, { name: 'Phone', inStock: true } ];
+// Challenge output = ['Book', 'Phone'];


### PR DESCRIPTION
## Description
Returns only the products that are in stock using the .filter() method.
**Extra Challenge:** Returns only the names of products in stock.

## Solution
```javascript
const inStockProducts = products.filter(product => product.inStock);
const inStockNames = products.filter(product => product.inStock).map(product => product.name);
```

## Testing
```bash
node product-stock.js
# Output:
# [ { name: 'Book', inStock: true }, { name: 'Phone', inStock: true } ]
# [ 'Book', 'Phone' ]
```

Closes #7102