### PR TITLE
fix: add GET mapping to HomeController for Spring Boot hello task

### DIFF
--- a/tasks/spring-boot/easy/hello/src/main/java/org/forkcommitmerge/hello/HomeController.java
+++ b/tasks/spring-boot/easy/hello/src/main/java/org/forkcommitmerge/hello/HomeController.java
@@ -1,20 +1,16 @@
 package org.forkcommitmerge.hello;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class HomeController {
 
-    /*
-     * TASK: Create a GET mapping for the index page ("/")
-     *
-     * Requirements:
-     * 1. Create a method that handles GET requests to the root path "/"
-     * 2. Add the text "Hello, Spring Boot" to the model with the key "message"
-     * 3. Return the view name "index" to render the template
-     *
-     * The template is already set up to display the message using Thymeleaf
-     * with the expression: th:text="${message}"
-     */
+    @GetMapping("/")
+    public String home(Model model) {
+        model.addAttribute("message", "Hello, Spring Boot");
+        return "index";
+    }
 
 }


### PR DESCRIPTION
Closes #6963

## What this PR does
Implements the GET mapping in `HomeController` that handles requests 
to the root path `/` and adds the "Hello, Spring Boot" message to the 
Thymeleaf model.

## Changes made
- Added `@GetMapping("/")` method in `HomeController.java`
- Method adds `message` attribute to the model
- Returns `"index"` view name for Thymeleaf to render

## Tested
- Ran `./mvnw spring-boot:run` locally
- Verified "Hello, Spring Boot" displays correctly at http://localhost:8080