### PR TITLE
fix: concatenate strings in PHP (#7280)

### DIFF
--- a/tasks/php/easy/index.php
+++ b/tasks/php/easy/index.php
@@ -1,6 +1,8 @@
 <?php
-$hello = "Hello, ";
+
+// PHP - Easy 1
+
+$hello = "Hello";
 $world = "World!";
 
-echo $hello . $world;
-?>
+echo $hello . ", " . $world;

--- a/tasks/php/easy/index.php
+++ b/tasks/php/easy/index.php
@@ -1,8 +1,6 @@
 <?php
-
-// PHP - Easy 1
-
-$hello = "Hello";
+$hello = "Hello, ";
 $world = "World!";
 
-// TODO: Implement rest of the string concatenation program
+echo $hello . $world;
+?>


### PR DESCRIPTION
Closes #7280

Implemented string concatenation using the `.` operator in PHP. The program concatenates `$hello` and `$world` and prints the result.