### PR TITLE
Add simple storage contract

### DIFF
--- a/tasks/solidity/easy/my_simple_storage/contracts/SimpleStorage.sol
+++ b/tasks/solidity/easy/my_simple_storage/contracts/SimpleStorage.sol
@@ -1,11 +1,14 @@
-// Solidity - Easy
-
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 contract SimpleStorage {
-    uint256 _number;
-    // TODO: Implement function to set the number
+    uint256 private storedNumber;
 
-    // TODO: Implement function to get the number
+    function set(uint256 _number) public {
+        storedNumber = _number;
+    }
+
+    function get() public view returns (uint256) {
+        return storedNumber;
+    }
 }


### PR DESCRIPTION
## Summary

Implemented the SimpleStorage Solidity contract.

## Changes

- Added a private `storedNumber` variable
- Added `set(uint256 _number)` function to store a number
- Added `get()` function to retrieve the stored number

## Testing

Ran:

```bash
truffle compile

## Result:

-Compiled successfully using solc 0.8.21