### PR TITLE
feat: implement startScreenTimeWarning function

### DIFF
--- a/tasks/javascript/medium/screenTimeWarning/screenTimeWarning.js
+++ b/tasks/javascript/medium/screenTimeWarning/screenTimeWarning.js
@@ -8,7 +8,16 @@
  */
 
 function startScreenTimeWarning(limitMinutes = 30) {
+  const startTime = Date.now();
+  const limitMs = limitMinutes * 60 * 1000;
 
+  const interval = setInterval(() => {
+    const elapsed = Date.now() - startTime;
+    if (elapsed >= limitMs) {
+      console.log("Time to take a break! You've been browsing for " + limitMinutes + " minutes.");
+      clearInterval(interval);
+    }
+  }, 1000);
 }
 
 // Example usage


### PR DESCRIPTION
Implements startScreenTimeWarning function for issue #6883.

- Function tracks time-on-page using setInterval
- Logs a friendly break reminder to console after the configured limit
- Default limit is 30 minutes, configurable via parameter