### PR TITLE
fix: filter in-stock products and return their names

### DIFF
--- a/tasks/javascript/medium/product-stock.js
+++ b/tasks/javascript/medium/product-stock.js
@@ -1,13 +1,14 @@
 // JavaScript - Medium
 
-  // TODO: return only products that are in stock using .filter() method;
-  // Extra Challenge: return only the names of products in stock;
-
 const products = [
     { name: "Book", inStock: true },
     { name: "Pen", inStock: false },
     { name: "Phone", inStock: true },
     { name: "Mug", inStock: false }
   ];
-  // TODO output = [ { name: 'Book', inStock: true }, { name: 'Phone', inStock: true } ];
-  // Challenge output = ['Book', 'Phone'];
+
+const output = products.filter((product) => product.inStock);
+const challengeOutput = output.map((product) => product.name);
+
+console.log(output);
+console.log(challengeOutput);


### PR DESCRIPTION
## Pull Request Type

What kind of change does this PR introduce?

- [x] Solved an issue/task
- [ ] Suggest new feature/task for Fork, Commit, Merge
- [ ] Other... Please describe:

## Issue Number

Issue Number: 7477


## Summary
- Filter the `products` array with `.filter()` to keep only items where `inStock` is `true`
- Map the filtered list to product names for the extra challenge (`['Book', 'Phone']`)
- Log both results so `node product-stock.js` matches the expected output