### PR TITLE
Solve SQL easy task: create users table

### DIFF
--- a/tasks/sql/easy/create_users.sql
+++ b/tasks/sql/easy/create_users.sql
@@ -1,6 +1,7 @@
 -- SQL - Easy
 
 CREATE TABLE users (
-    -- TODO: Add all the requested fields
+    id INTEGER PRIMARY KEY,
+    name TEXT,
+    email TEXT
 );
-


### PR DESCRIPTION
Closes #7890

Added the three requested columns to `tasks/sql/easy/create_users.sql`. `id` is declared as `INTEGER PRIMARY KEY`, which is what makes the `pk` flag appear in the expected output.

Verified against the output the issue asks for:

```sql
0|id|INTEGER|0||1
1|name|TEXT|0||0
2|email|TEXT|0||0
```
