### PR TITLE
Solve Markdown easy task: correct formatting

### DIFF
--- a/tasks/markdown/easy/introduction.md
+++ b/tasks/markdown/easy/introduction.md
@@ -1,10 +1,10 @@
 <!-- Markdown - Easy -->
 
- - Header
+# Header
 
 - this is
 - a list
 - with proper
--formatting
+- formatting
 
-Visit our website [here] (https://forkcommitmerge.dev)
+Visit our website [here](https://forkcommitmerge.dev)


### PR DESCRIPTION
Closes #7788

Fixed the Markdown in `tasks/markdown/easy/introduction.md`:

- ` - Header` was a list item, not a heading, so it is now `# Header`.
- `-formatting` had no space after the dash, so it did not render as a list item.
- `[here] (https://forkcommitmerge.dev)` had a space between the label and the target, which stops it from rendering as a link.
