### PR TITLE
Solve Solidity easy issue: SimpleStorage contract

### DIFF
--- a/tasks/solidity/easy/my_simple_storage/contracts/SimpleStorage.sol
+++ b/tasks/solidity/easy/my_simple_storage/contracts/SimpleStorage.sol
@@ -4,8 +4,13 @@
 pragma solidity ^0.8.0;
 
 contract SimpleStorage {
-    uint256 _number;
-    // TODO: Implement function to set the number
+    uint256 private storedNumber;
 
-    // TODO: Implement function to get the number
+    function set(uint256 _number) public {
+        storedNumber = _number;
+    } 
+
+    function get() public view returns (uint256) {
+        return storedNumber;
+    }
 }


### PR DESCRIPTION
Fixes #8065

Implemented a simple SimpleStorage smart contract in Solidity with:
- `set(uint256 _number)` function to store a number
- `get()` function to retrieve the stored number

Tested locally using Truffle:
- Compiled successfully with `truffle compile`
- Deployed on local blockchain with `truffle develop` + `migrate`
- Verified via console: `set(42)` followed by `get()` returned `42`