### PR TITLE
feat: add GET mapping to HomeController for Spring Boot hello task

### DIFF
--- a/tasks/spring-boot/easy/hello/src/main/java/org/forkcommitmerge/hello/HomeController.java
+++ b/tasks/spring-boot/easy/hello/src/main/java/org/forkcommitmerge/hello/HomeController.java
@@ -1,20 +1,16 @@
 package org.forkcommitmerge.hello;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class HomeController {
 
-    /*
-     * TASK: Create a GET mapping for the index page ("/")
-     *
-     * Requirements:
-     * 1. Create a method that handles GET requests to the root path "/"
-     * 2. Add the text "Hello, Spring Boot" to the model with the key "message"
-     * 3. Return the view name "index" to render the template
-     *
-     * The template is already set up to display the message using Thymeleaf
-     * with the expression: th:text="${message}"
-     */
+    @GetMapping("/")
+    public String home(Model model) {
+        model.addAttribute("message", "Hello, Spring Boot");
+        return "index";
+    }
 
 }


### PR DESCRIPTION
## Issue Number

Issue Number: #8113

## Summary

Implements the root path handler in `HomeController` so the Spring Boot easy task
renders the "Hello, Spring Boot" message. Previously the controller declared no
request mapping, so `/` fell through to Spring Boot's welcome-page handling and the
template rendered with an empty `message` attribute.

## Changes

- `tasks/spring-boot/easy/hello/src/main/java/org/forkcommitmerge/hello/HomeController.java`
  - Added a `@GetMapping("/")` handler that adds `"Hello, Spring Boot"` to the model
    under the key `message` and returns the `index` view.
  - Added the required `Model` and `GetMapping` imports.

No other files were touched, and no dependencies were added or changed.

## Testing

- Ran the existing test suite with `./mvnw test` before and after the change:
  1 test, all passing, `BUILD SUCCESS` in both runs.
- Verified `GET /` returns 200, resolves the `index` view, and renders
  "Hello, Spring Boot" through the Thymeleaf template.